### PR TITLE
Update version parsing to allow running from branch ref as well

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -3,7 +3,26 @@ PLATFORMS=$1
 LEVEL=$2
 SRCDIR=$3
 VERSION=$4
-VERSION=${VERSION/refs\/tags\/libwallet-/}
+echo "VERSION=${VERSION}"
+
+# fix version for branches and tags
+case $VERSION in
+
+*"heads"*)
+  VERSION=${VERSION/refs\/heads\//}
+  echo "Parsed BRANCH from git ref: ${VERSION}"
+  ;;
+
+*"tags"*)
+  VERSION=${VERSION/refs\/tags\/libwallet-/}
+  echo "Parsed TAG from git ref: ${VERSION}"
+  ;;
+
+*)
+  echo "Failed to parse a version from ${VERSION}"
+  exit 1
+  ;;
+esac
 
 echo "Action Build Libs: Invoking with"
 echo "PLATFORMS: ${PLATFORMS}"
@@ -11,7 +30,7 @@ echo "LEVEL: ${LEVEL}"
 echo "SRCDIR: ${SRCDIR}"
 echo "VERSION: ${VERSION}"
 
-IFS=';' read -ra PLATFORMARRAY <<< "$PLATFORMS"
+IFS=';' read -ra PLATFORMARRAY <<<"$PLATFORMS"
 
 for platform in "${PLATFORMARRAY[@]}"; do
   /scripts/build_jnilib.sh ${platform} ${LEVEL} ${SRCDIR} || exit 1


### PR DESCRIPTION
Allows this action to be run from a branch as well as on tag, so that we can start building on tari development branch and ensure the libwallet build doesn't break.  