### PR TITLE
update rust-ndk image to 1.57

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Custom dockerfile to build Tari libwallet for android
 FROM quay.io/tarilabs/sqlite-mobile:201911192122 as sqlite
 FROM quay.io/tarilabs/openssl-android:202101052000 as ssl
-FROM quay.io/tarilabs/rust-ndk:1.53.0_r21b
+FROM quay.io/tarilabs/rust-ndk:1.57.0_r21b
 # Copy the precompiled sqlite binaries
 COPY --from=sqlite /platforms /platforms
 COPY --from=ssl /platforms /platforms


### PR DESCRIPTION
updates the base image 

also requires a new git tag on this repo please: `v0.3.3` 

required for tari-project/tari#3553